### PR TITLE
generate_obj call fails without attribute 'gaussian_states'

### DIFF
--- a/examples/slds_example_figure.py
+++ b/examples/slds_example_figure.py
@@ -97,6 +97,7 @@ def sample_slds_model():
     z = np.repeat(z, D)
 
     statesobj = slds._states_class(model=slds, T=z.size, stateseq=z, inputs=np.ones((z.size, 1)))
+    statesobj.generate_gaussian_states()
     y = statesobj.data = statesobj.generate_obs()
     x = statesobj.gaussian_states
     slds.states_list.append(statesobj)


### PR DESCRIPTION
Does this fix look reasonable?

Here is the example script error before the changes in this pull request:

    ecashin@9a2fcfbcf8d3:/mnt/host$ python slds_example_figure.py
    Traceback (most recent call last):
      File "slds_example_figure.py", line 240, in <module>
        z,x,y,slds = sample_slds_model()
      File "slds_example_figure.py", line 105, in sample_slds_model
        y = statesobj.data = statesobj.generate_obs()
      File "/usr/local/lib/python3.6/site-packages/pyslds/states.py", line 77, in generate_obs
        dss, gss = self.stateseq, self.gaussian_states
    AttributeError: 'HMMSLDSStatesEigen' object has no attribute 'gaussian_states'
    ecashin@9a2fcfbcf8d3:/mnt/host$ 
